### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "recharts": "^2.15.3",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.4"
+        "zod": "^3.24.4",
+        "express-rate-limit": "^7.5.0"
     },
     "devDependencies": {
         "@types/node": "^20.11.16",


### PR DESCRIPTION
Potential fix for [https://github.com/YanDao0313/elderly_carefree/security/code-scanning/1](https://github.com/YanDao0313/elderly_carefree/security/code-scanning/1)

To address the issue, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests that can be made to the `generateAudio` route within a specified time window. Specifically, we will:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter specifically to the `generateAudio` route.

This approach ensures that the `generateAudio` route is protected from abuse without affecting other routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
